### PR TITLE
Handle paths with non-ASCII chars on non-UTF8 Windows; Issue#1.

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -10275,7 +10275,7 @@ utf8_to_utf16(const char *src, MDB_name *dst, int xtra)
 	int rc, need = 0;
 	wchar_t *result = NULL;
 	for (;;) {					/* malloc result, then fill it in */
-		need = MultiByteToWideChar(CP_UTF8, 0, src, -1, result, need);
+		need = MultiByteToWideChar(CP_ACP, 0, src, -1, result, need);  /* Use ACP for current Windows codepage */
 		if (!need) {
 			rc = ErrCode();
 			free(result);


### PR DESCRIPTION
Solving Issue #1 by changing CP_UTF8 to CP_ACP.